### PR TITLE
Allow user to specify output path for processed video

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ python detect_video.py --video 0
 
 # video file
 python detect_video.py --video path_to_file.mp4 --weights ./checkpoints/yolov3-tiny.tf --tiny
+
+# video file with output
+python detect_video.py --video path_to_file.mp4 --output ./output.avi
 ```
 
 ### Training
@@ -245,6 +248,23 @@ detect.py:
     (default: './data/girl.png')
   --output: path to output image
     (default: './output.jpg')
+  --[no]tiny: yolov3 or yolov3-tiny
+    (default: 'false')
+  --weights: path to weights file
+    (default: './checkpoints/yolov3.tf')
+  --num_classes: number of classes in the model
+    (default: '80')
+    (an integer)
+
+detect_video.py:
+  --classes: path to classes file
+    (default: './data/coco.names')
+  --video: path to input video (use 0 for cam)
+    (default: './data/video.mp4')
+  --output: path to output video (remember to set right codec for given format. e.g. XVID for .avi)
+    (default: None)
+  --output_format: codec used in VideoWriter when saving video to file
+    (default: 'XVID)
   --[no]tiny: yolov3 or yolov3-tiny
     (default: 'false')
   --weights: path to weights file

--- a/detect_video.py
+++ b/detect_video.py
@@ -17,6 +17,8 @@ flags.DEFINE_boolean('tiny', False, 'yolov3 or yolov3-tiny')
 flags.DEFINE_integer('size', 416, 'resize images to')
 flags.DEFINE_string('video', './data/video.mp4',
                     'path to video file or number for webcam)')
+flags.DEFINE_string('output', None, 'path to output video')
+flags.DEFINE_string('output_format', 'XVID', 'codec used in VideoWriter when saving video to file')
 flags.DEFINE_integer('num_classes', 80, 'number of classes in the model')
 
 
@@ -38,6 +40,17 @@ def main(_argv):
         vid = cv2.VideoCapture(int(FLAGS.video))
     except:
         vid = cv2.VideoCapture(FLAGS.video)
+
+    out = None
+
+    if FLAGS.output:
+        # by default VideoCapture returns float instead of int
+        width = int(vid.get(cv2.CAP_PROP_FRAME_WIDTH))
+        height = int(vid.get(cv2.CAP_PROP_FRAME_HEIGHT))
+        fps = int(vid.get(cv2.CAP_PROP_FPS))
+        codec = cv2.VideoWriter_fourcc(*FLAGS.output_format)
+        out = cv2.VideoWriter(FLAGS.output, codec, fps, (width, height))
+
     while True:
         _, img = vid.read()
 
@@ -58,6 +71,8 @@ def main(_argv):
         img = draw_outputs(img, (boxes, scores, classes, nums), class_names)
         img = cv2.putText(img, "Time: {:.2f}ms".format(sum(times)/len(times)*1000), (0, 30),
                           cv2.FONT_HERSHEY_COMPLEX_SMALL, 1, (0, 0, 255), 2)
+        if FLAGS.output:
+            out.write(img)
         cv2.imshow('output', img)
         if cv2.waitKey(1) == ord('q'):
             break


### PR DESCRIPTION
Two flags added to detect_video.py
```
--output  # where to save output video (default None)
--output_format  # which codec to use (default XVID)
```
It's not invasive, the default value is set to `None` so it won't output anything.
The output is saved in the same resolution and frame rate.