### PR TITLE
Fixed yolo_boxes function for rectangles dimension

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -21,7 +21,7 @@ def main(_argv):
     load_darknet_weights(yolo, FLAGS.weights, FLAGS.tiny)
     logging.info('weights loaded')
 
-    img = np.random.random((1, 320, 320, 3)).astype(np.float32)
+    img = np.random.random((1, 576, 1024, 3)).astype(np.float32)
     output = yolo(img)
     logging.info('sanity check passed')
 

--- a/convert.py
+++ b/convert.py
@@ -21,7 +21,7 @@ def main(_argv):
     load_darknet_weights(yolo, FLAGS.weights, FLAGS.tiny)
     logging.info('weights loaded')
 
-    img = np.random.random((1, 576, 1024, 3)).astype(np.float32)
+    img = np.random.random((1, 320, 320, 3)).astype(np.float32)
     output = yolo(img)
     logging.info('sanity check passed')
 

--- a/yolov3_tf2/models.py
+++ b/yolov3_tf2/models.py
@@ -150,7 +150,7 @@ def YoloOutput(filters, anchors, classes, name=None):
 
 def yolo_boxes(pred, anchors, classes):
     # pred: (batch_size, grid, grid, anchors, (x, y, w, h, obj, ...classes))
-    grid_size = tf.shape(pred)[1]
+    grid_size = tf.shape(pred)[1:3]
     box_xy, box_wh, objectness, class_probs = tf.split(
         pred, (2, 2, 1, classes), axis=-1)
 
@@ -160,7 +160,7 @@ def yolo_boxes(pred, anchors, classes):
     pred_box = tf.concat((box_xy, box_wh), axis=-1)  # original xywh for loss
 
     # !!! grid[x][y] == (y, x)
-    grid = tf.meshgrid(tf.range(grid_size), tf.range(grid_size))
+    grid = tf.meshgrid(tf.range(grid_size[1]), tf.range(grid_size[0]))
     grid = tf.expand_dims(tf.stack(grid, axis=-1), axis=2)  # [gx, gy, 1, 2]
 
     box_xy = (box_xy + tf.cast(grid, tf.float32)) / \


### PR DESCRIPTION
I have pre trained model and set network size multiple of 32:  `width=1024 height=576` accordingly to this repository [AlexeyAB](https://github.com/AlexeyAB/darknet) 
I want convert my yolo weight to tensorflow platform and served by tf-serving. Find your repository and when I want to convert my model faced by problem in yolo_boxes function in model.py file. In advance, thank you to consider my changes.

Thanks 