### PR TITLE
Global split for dataset

### DIFF
--- a/tools/voc2012.py
+++ b/tools/voc2012.py
@@ -93,7 +93,7 @@ def main(_argv):
 
     writer = tf.io.TFRecordWriter(FLAGS.output_file)
     image_list = open(os.path.join(
-        FLAGS.data_dir, 'ImageSets', 'Main', 'aeroplane_%s.txt' % FLAGS.split)).read().splitlines()
+        FLAGS.data_dir, 'ImageSets', 'Main', '%s.txt' % FLAGS.split)).read().splitlines()
     logging.info("Image list loaded: %d", len(image_list))
     for image in tqdm.tqdm(image_list):
         name, _ = image.split()


### PR DESCRIPTION
Using `aeroplane_%s.txt` means it is specific for the class Aeroplane. Just `%s.txt` is needed for a global dataset split.