### PR TITLE
Add GPU set_memory_growth to convert -conv2d error

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -3,6 +3,7 @@ from absl.flags import FLAGS
 import numpy as np
 from yolov3_tf2.models import YoloV3, YoloV3Tiny
 from yolov3_tf2.utils import load_darknet_weights
+import tensorflow as tf
 
 flags.DEFINE_string('weights', './data/yolov3.weights', 'path to weights file')
 flags.DEFINE_string('output', './checkpoints/yolov3.tf', 'path to output')
@@ -11,6 +12,10 @@ flags.DEFINE_integer('num_classes', 80, 'number of classes in the model')
 
 
 def main(_argv):
+    physical_devices = tf.config.experimental.list_physical_devices('GPU')
+    if len(physical_devices) > 0:
+        tf.config.experimental.set_memory_growth(physical_devices[0], True)
+
     if FLAGS.tiny:
         yolo = YoloV3Tiny(classes=FLAGS.num_classes)
     else:


### PR DESCRIPTION
Add the same Tensorflow 2.0 .set_memory_growth to convert.py to remove the Conv2D - cuDNN may not be properly installed error
