### PR TITLE
Fix issue when setting memory growth

### DIFF
--- a/detect.py
+++ b/detect.py
@@ -23,8 +23,8 @@ flags.DEFINE_integer('num_classes', 80, 'number of classes in the model')
 
 def main(_argv):
     physical_devices = tf.config.experimental.list_physical_devices('GPU')
-    if len(physical_devices) > 0:
-        tf.config.experimental.set_memory_growth(physical_devices[0], True)
+    for physical_device in physical_devices:
+        tf.config.experimental.set_memory_growth(physical_device, True)
 
     if FLAGS.tiny:
         yolo = YoloV3Tiny(classes=FLAGS.num_classes)

--- a/detect_video.py
+++ b/detect_video.py
@@ -24,8 +24,8 @@ flags.DEFINE_integer('num_classes', 80, 'number of classes in the model')
 
 def main(_argv):
     physical_devices = tf.config.experimental.list_physical_devices('GPU')
-    if len(physical_devices) > 0:
-        tf.config.experimental.set_memory_growth(physical_devices[0], True)
+    for physical_device in physical_devices:
+        tf.config.experimental.set_memory_growth(physical_device, True)
 
     if FLAGS.tiny:
         yolo = YoloV3Tiny(classes=FLAGS.num_classes)
@@ -63,7 +63,7 @@ def main(_argv):
             time.sleep(0.1)
             continue
 
-        img_in = cv2.cvtColor(img, cv2.COLOR_BGR2RGB) 
+        img_in = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
         img_in = tf.expand_dims(img_in, 0)
         img_in = transform_images(img_in, FLAGS.size)
 

--- a/train.py
+++ b/train.py
@@ -46,8 +46,8 @@ flags.DEFINE_integer('weights_num_classes', None, 'specify num class for `weight
 
 def main(_argv):
     physical_devices = tf.config.experimental.list_physical_devices('GPU')
-    if len(physical_devices) > 0:
-        tf.config.experimental.set_memory_growth(physical_devices[0], True)
+    for physical_device in physical_devices:
+        tf.config.experimental.set_memory_growth(physical_device, True)
 
     if FLAGS.tiny:
         model = YoloV3Tiny(FLAGS.size, training=True,


### PR DESCRIPTION
When calling tf.config.experimental.set_memory_growth, we want to set the value to True for all physical devices.

Otherwise, the following ValueError is produced: 'Memory growth cannot differ between GPU devices'

I ran into this issue when running `python detect.py --weights ./checkpoints/yolov3-tiny.tf --tiny --image ./data/street.jpg` on a device with two RTX 2080TI.

```
raise ValueError("Memory growth cannot differ between GPU devices")
 ValueError: Memory growth cannot differ between GPU devices
```