### PR TITLE
modify yolov3 loss to get better detect result

### DIFF
--- a/yolov3_tf2/models.py
+++ b/yolov3_tf2/models.py
@@ -148,16 +148,17 @@ def YoloOutput(filters, anchors, classes, name=None):
     return yolo_output
 
 
-def yolo_boxes(pred, anchors, classes):
+def yolo_boxes(pred, anchors, classes, calc_loss=False):
     # pred: (batch_size, grid, grid, anchors, (x, y, w, h, obj, ...classes))
     grid_size = tf.shape(pred)[1]
     box_xy, box_wh, objectness, class_probs = tf.split(
         pred, (2, 2, 1, classes), axis=-1)
 
     box_xy = tf.sigmoid(box_xy)
-    objectness = tf.sigmoid(objectness)
-    class_probs = tf.sigmoid(class_probs)
-    pred_box = tf.concat((box_xy, box_wh), axis=-1)  # original xywh for loss
+
+    if calc_loss is False:
+        objectness = tf.sigmoid(objectness)
+        class_probs = tf.sigmoid(class_probs)
 
     # !!! grid[x][y] == (y, x)
     grid = tf.meshgrid(tf.range(grid_size), tf.range(grid_size))
@@ -171,7 +172,7 @@ def yolo_boxes(pred, anchors, classes):
     box_x2y2 = box_xy + box_wh / 2
     bbox = tf.concat([box_x1y1, box_x2y2], axis=-1)
 
-    return bbox, objectness, class_probs, pred_box
+    return bbox, objectness, class_probs
 
 
 def yolo_nms(outputs, anchors, masks, classes):
@@ -260,10 +261,11 @@ def YoloLoss(anchors, classes=80, ignore_thresh=0.5):
     def yolo_loss(y_true, y_pred):
         # 1. transform all pred outputs
         # y_pred: (batch_size, grid, grid, anchors, (x, y, w, h, obj, ...cls))
-        pred_box, pred_obj, pred_class, pred_xywh = yolo_boxes(
-            y_pred, anchors, classes)
-        pred_xy = pred_xywh[..., 0:2]
-        pred_wh = pred_xywh[..., 2:4]
+        pred_box, pred_obj, pred_class = yolo_boxes(
+            y_pred, anchors, classes, calc_loss=True)
+
+        pred_xy = (pred_box[..., 0:2] + pred_box[..., 2:4]) / 2
+        pred_wh = pred_box[..., 2:4] - pred_box[..., 0:2]
 
         # 2. transform all true outputs
         # y_true: (batch_size, grid, grid, anchors, (x1, y1, x2, y2, obj, cls))
@@ -274,16 +276,6 @@ def YoloLoss(anchors, classes=80, ignore_thresh=0.5):
 
         # give higher weights to small boxes
         box_loss_scale = 2 - true_wh[..., 0] * true_wh[..., 1]
-
-        # 3. inverting the pred box equations
-        grid_size = tf.shape(y_true)[1]
-        grid = tf.meshgrid(tf.range(grid_size), tf.range(grid_size))
-        grid = tf.expand_dims(tf.stack(grid, axis=-1), axis=2)
-        true_xy = true_xy * tf.cast(grid_size, tf.float32) - \
-            tf.cast(grid, tf.float32)
-        true_wh = tf.math.log(true_wh / anchors)
-        true_wh = tf.where(tf.math.is_inf(true_wh),
-                           tf.zeros_like(true_wh), true_wh)
 
         # 4. calculate all masks
         obj_mask = tf.squeeze(true_obj, -1)
@@ -300,12 +292,12 @@ def YoloLoss(anchors, classes=80, ignore_thresh=0.5):
             tf.reduce_sum(tf.square(true_xy - pred_xy), axis=-1)
         wh_loss = obj_mask * box_loss_scale * \
             tf.reduce_sum(tf.square(true_wh - pred_wh), axis=-1)
-        obj_loss = binary_crossentropy(true_obj, pred_obj)
+        obj_loss = binary_crossentropy(true_obj, pred_obj, from_logits=True)
         obj_loss = obj_mask * obj_loss + \
             (1 - obj_mask) * ignore_mask * obj_loss
         # TODO: use binary_crossentropy instead
         class_loss = obj_mask * sparse_categorical_crossentropy(
-            true_class_idx, pred_class)
+            true_class_idx, pred_class, from_logits=True)
 
         # 6. sum over (batch, gridx, gridy, anchors) => (batch, 1)
         xy_loss = tf.reduce_sum(xy_loss, axis=(1, 2, 3))

--- a/yolov3_tf2/utils.py
+++ b/yolov3_tf2/utils.py
@@ -96,7 +96,16 @@ def broadcast_iou(box_1, box_2):
         (box_1[..., 3] - box_1[..., 1])
     box_2_area = (box_2[..., 2] - box_2[..., 0]) * \
         (box_2[..., 3] - box_2[..., 1])
-    return int_area / (box_1_area + box_2_area - int_area)
+    union_area = box_1_area + box_2_area - int_area
+    iou = int_area / union_area
+    
+    enclose_left_up = tf.minimum(box_1[..., :2], box_2[..., :2])
+    enclose_right_down = tf.maximum(box_1[..., 2:], box_2[..., 2:])
+    enclose = tf.maximum(enclose_right_down - enclose_left_up, 0.0)
+    enclose_area = enclose[..., 0] * enclose[..., 1]
+    giou = iou - 1.0 * (enclose_area - union_area) / enclose_area
+
+    return giou
 
 
 def draw_outputs(img, outputs, class_names):


### PR DESCRIPTION
i met issue that nothing or very limited objects were detected with fine tune weights, after 2 or 80 epochs. since i used coco 2014 dataset, I made a big mistake that the box value of 2014 is: y1, x1, y2, x2. After change to x1, y1, x2, y2, the major problem fixed.

but i was confused that why only limited objects were detected even the box value is misaligned after 80 epochs. and part of loss code also confuse me. So i make some changes on yolov3 tf2 project. it seems to me that it work better. Hope it can help other members to solve their similar issue. 

The result is tested on 5th epoch with lr(1e-4), batch_size(16):
Origin result:
![image](https://user-images.githubusercontent.com/731496/81494458-b4fa0a00-92db-11ea-8f35-1b8a1683c844.png)

New result:
![image](https://user-images.githubusercontent.com/731496/81494472-ce02bb00-92db-11ea-86a0-6e826fee53cc.png)

You can notice that the confidence level of new result is much better than origin result.
if anything i misunderstand, please correct me. thanks