### PR TITLE
Revise voc2012 dataset preparing script

### DIFF
--- a/tools/voc2012.py
+++ b/tools/voc2012.py
@@ -93,10 +93,9 @@ def main(_argv):
 
     writer = tf.io.TFRecordWriter(FLAGS.output_file)
     image_list = open(os.path.join(
-        FLAGS.data_dir, 'ImageSets', 'Main', 'aeroplane_%s.txt' % FLAGS.split)).read().splitlines()
+        FLAGS.data_dir, 'ImageSets', 'Main', '%s.txt' % FLAGS.split)).read().splitlines()
     logging.info("Image list loaded: %d", len(image_list))
-    for image in tqdm.tqdm(image_list):
-        name, _ = image.split()
+    for name in tqdm.tqdm(image_list):
         annotation_xml = os.path.join(
             FLAGS.data_dir, 'Annotations', name + '.xml')
         annotation_xml = lxml.etree.fromstring(open(annotation_xml).read())


### PR DESCRIPTION
Although #252 has explained that "classname_train.txt" contains all the images while not the "classname" only images, the usage of "aeroplane_%s.txt" is still easily misunderstood. It leads to #193 , which turn out to be a buggy fix.

I would like to revise the script to use train.txt/eval.txt instead of the class-specific list file.