### PR TITLE
Fix tflite export

### DIFF
--- a/tools/export_tflite.py
+++ b/tools/export_tflite.py
@@ -23,7 +23,7 @@ flags.DEFINE_string('image', './data/girl.png', 'path to input image')
 flags.DEFINE_integer('num_classes', 80, 'number of classes in the model')
 flags.DEFINE_integer('size', 416, 'image size')
 
-# TODO: This is broken DOES NOT WORK !!
+
 def main(_argv):
     if FLAGS.tiny:
         yolo = YoloV3Tiny(size=FLAGS.size, classes=FLAGS.num_classes)

--- a/tools/export_tflite.py
+++ b/tools/export_tflite.py
@@ -34,6 +34,11 @@ def main(_argv):
     logging.info('weights loaded')
 
     converter = tf.lite.TFLiteConverter.from_keras_model(yolo)
+
+    # Fix from https://stackoverflow.com/questions/64490203/tf-lite-non-max-suppression
+    converter.experimental_new_converter = True
+    converter.target_spec.supported_ops = [tf.lite.OpsSet.TFLITE_BUILTINS, tf.lite.OpsSet.SELECT_TF_OPS]
+
     tflite_model = converter.convert()
     open(FLAGS.output, 'wb').write(tflite_model)
     logging.info("model saved to: {}".format(FLAGS.output))

--- a/yolov3_tf2/dataset.py
+++ b/yolov3_tf2/dataset.py
@@ -6,7 +6,7 @@ def transform_targets_for_output(y_true, grid_size, anchor_idxs):
     # y_true: (N, boxes, (x1, y1, x2, y2, class, best_anchor))
     N = tf.shape(y_true)[0]
 
-    # y_true_out: (N, grid, grid, anchors, [x, y, w, h, obj, class])
+    # y_true_out: (N, grid, grid, anchors, [x1, y1, x2, y2, obj, class])
     y_true_out = tf.zeros(
         (N, grid_size, grid_size, tf.shape(anchor_idxs)[0], 6))
 


### PR DESCRIPTION
Hi,

I was looking into converting model using tflite converter and stumble on two issues:
 * tf.image.combined_non_max_suppression not supported by tflite
 * tf.size not supported by tflite (used in tf.meshgrid function)

For tf.image.combined_non_max_suppression I found a fix here:
https://stackoverflow.com/questions/64490203/tf-lite-non-max-suppression

For tf.size I simply reimplement a meshgrid function that suit our needs.

I made some test and got identical results using tools/export_tflite.py and detect.py on data/girl.png using tiny darknet.
