### PR TITLE
Add multi-gpu functionality

### DIFF
--- a/train.py
+++ b/train.py
@@ -27,7 +27,7 @@ flags.DEFINE_string('weights', './checkpoints/yolov3.tf',
 flags.DEFINE_string('classes', './data/coco.names', 'path to classes file')
 flags.DEFINE_enum('mode', 'fit', ['fit', 'eager_fit', 'eager_tf'],
                   'fit: model.fit, '
-                  'eager_fit: model.fit(RUN_EAGERLY=True), '
+                  'eager_fit: model.fit(run_eagerly=True), '
                   'eager_tf: custom GradientTape')
 flags.DEFINE_enum('transfer', 'none',
                   ['none', 'darknet', 'no_output', 'frozen', 'fine_tune'],


### PR DESCRIPTION
These changes allow for training to be completed using more than 1 GPU. Using multiple GPUs is optional, defined by a new boolean argument. This was to address a few Issues raised discussing/requesting multiple GPU.

A couple chunks of code got moved around to implement this without having to copy code in multiple spaces. I also added tracking training time.

I successfully test ran these changes on Ubuntu 18.04 LTS (Bionic Beaver) using 2 GPU.

If you like the idea and want anything changed in the pull request feel free to suggest. 