### PR TITLE
Correct score for one-class detection

### DIFF
--- a/yolov3_tf2/models.py
+++ b/yolov3_tf2/models.py
@@ -197,7 +197,11 @@ def yolo_nms(outputs, anchors, masks, classes):
     confidence = tf.concat(c, axis=1)
     class_probs = tf.concat(t, axis=1)
 
-    scores = confidence * class_probs
+    # If we only have one class, do not multiply by class_prob (always 0.5)
+    if classes == 1:
+        scores = confidence
+    else:
+        scores = confidence * class_probs
 
     dscores = tf.squeeze(scores, axis=0)
     scores = tf.reduce_max(dscores,[1])


### PR DESCRIPTION
See comment in See https://github.com/zzh8829/yolov3-tf2/pull/311

I think the score in yolo_nms is calculated wrong when only having one class. The model cannot learn anything about the class since the associated loss is always 0 --> class probability is always <= 0.5 --> score is always <= 0.5


Ah and by the way: Awesome work :)
Your model works very well when trained trying to build an aimbot: https://github.com/makra89/Quake_AI